### PR TITLE
Allow alternate SDA and SCL pins to be declared in init()

### DIFF
--- a/Seeed_BME280.cpp
+++ b/Seeed_BME280.cpp
@@ -2,12 +2,29 @@
 
 bool BME280::init(int i2c_addr)
 {
+
+
+  _devAddr = i2c_addr;
+  Wire.begin();
+
+  return (readCalibration());
+}
+
+bool BME280::init(int sda, int scl, int i2c_addr)
+// sda and scl allow for alternate SDA and SCL pins to be used
+{
+
+
+  _devAddr = i2c_addr;
+  Wire.begin(sda,scl);
+
+  return (readCalibration());
+}
+
+bool BME280::readCalibration()
+{
   uint8_t retry = 0;
   uint8_t chip_id = 0;
-
-
-  _devAddr = i2c_addr;  
-  Wire.begin();
 
   while((retry++ < 5) && (chip_id != 0x60))
   {
@@ -206,11 +223,11 @@ uint32_t BME280::BME280Read24(uint8_t reg)
     return 0;
   }
   else if(isTransport_OK == false) {
-    isTransport_OK = true;    
+    isTransport_OK = true;
     if(!init(_devAddr)) {
-#ifdef BMP280_DEBUG_PRINT      
+#ifdef BMP280_DEBUG_PRINT
       Serial.println("Device not connected or broken!");
-#endif      
+#endif
     }
   }
   data = Wire.read();

--- a/Seeed_BME280.h
+++ b/Seeed_BME280.h
@@ -46,6 +46,7 @@ class BME280
 {
 public:
   bool init(int i2c_addr = BME280_ADDRESS);
+  bool init(int sda, int scl, int i2c_addr = BME280_ADDRESS);
   float getTemperature(void);
   uint32_t getPressure(void);
   uint32_t getHumidity(void);
@@ -83,6 +84,7 @@ private:
   int16_t BME280ReadS16LE(uint8_t reg);
   uint32_t BME280Read24(uint8_t reg);
   void writeRegister(uint8_t reg, uint8_t val);
+  bool readCalibration();
 };
 
 #endif


### PR DESCRIPTION
Modifications to Seeed_BME280.cpp and Seeed_BME280.h to allow alternate SDA and SCL pins to be declared.  Value for the i2C address still defaults to BME280_ADDRESS. I have only tested this on a Wemos D1 Mini.

Syntax:
    bme280.init(SDA_PIN,SCL_PIN))
